### PR TITLE
fix: blockIds parameter casing

### DIFF
--- a/src/ExternalSearch.Providers.Dnb/DnBExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.Dnb/DnBExternalSearchProvider.cs
@@ -143,7 +143,7 @@ namespace CluedIn.ExternalSearch.Providers.DnB
                 }
                 else if (!string.IsNullOrWhiteSpace(jobData.BlockIds))
                 {
-                    request.AddQueryParameter("blockIds", jobData.BlockIds);
+                    request.AddQueryParameter("blockIDs", jobData.BlockIds);
                 }
                 else
                 {


### PR DESCRIPTION
## Description

Fixes `blockIDs` query parameter casing.

## How has it been tested? <!-- Remove if not needed -->

Manually
