### PR TITLE
fix: Convert globalUltimate domesticUltimate and industryCodes clues into properties

### DIFF
--- a/docs/4.6.1-release-notes.md
+++ b/docs/4.6.1-release-notes.md
@@ -2,6 +2,7 @@
 - Display help text on the Enricher Configuration page
 
 ### Fixes
+- Convert globalUltimate, domesticUltimate and industryCodes clues into properties to solve merging issues due to many identical clues
 
 ### Chore
 - Code clean up

--- a/src/ExternalSearch.Providers.Dnb/DnBExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.Dnb/DnBExternalSearchProvider.cs
@@ -170,6 +170,16 @@ public class DnBExternalSearchProvider : ExternalSearchProviderBase, IExtendedEn
             }
 
             var organization = data.organization ?? data.embeddedProduct.organization;
+
+            // Not using industry codes from extended match API
+            if (data.embeddedProduct.organization != null)
+            {
+                if (organization.industryCodes != null && organization.industryCodes.Any())
+                {
+                    organization.industryCodes.Clear();
+                }
+            }
+
             if (organization == null)
             {
                 throw new ApplicationException("Could not execute external search query - DnB returned empty organization");
@@ -240,20 +250,7 @@ public class DnBExternalSearchProvider : ExternalSearchProviderBase, IExtendedEn
         metadata.OriginEntityCode = code;
         metadata.Codes.Add(request.EntityMetaData.OriginEntityCode);
 
-        var domesticUltimateDuns = resultItem.Data.organization?.corporateLinkage?.domesticUltimate?.duns;
-        var globalUltimateDuns = resultItem.Data.organization?.corporateLinkage?.globalUltimate?.duns;
-
-        if (!string.IsNullOrWhiteSpace(globalUltimateDuns))
-        {
-            var globalCode = new EntityCode(request.EntityMetaData.EntityType, "DnB", globalUltimateDuns);
-            metadata.OutgoingEdges.Add(new EntityEdge(new EntityReference(request.EntityMetaData.OriginEntityCode), new EntityReference(globalCode), "/GlobalUltimateParent"));
-        }
-
-        if (!string.IsNullOrWhiteSpace(domesticUltimateDuns))
-        {
-            var domesticCode = new EntityCode(request.EntityMetaData.EntityType, "DnB", domesticUltimateDuns);
-            metadata.OutgoingEdges.Add(new EntityEdge(new EntityReference(request.EntityMetaData.OriginEntityCode), new EntityReference(domesticCode), "/DomesticUltimateParent"));
-        }
+        PopulatePrimaryAddresses(metadata, resultItem);
 
         if (resultItem.Data.organization?.dunsControlStatus != null)
         {
@@ -274,32 +271,22 @@ public class DnBExternalSearchProvider : ExternalSearchProviderBase, IExtendedEn
                 metadata.Properties[StaticDnBVocabulary.BusinessPartner.OperatingStatusDescription] = resultItem.Data.organization.dunsControlStatus.operatingStatus?.description.PrintIfAvailable();
             }
         }
+
         // DUNS Numbers
         metadata.Properties[StaticDnBVocabulary.BusinessPartner.Duns] = resultItem.Data.organization?.duns;
-        metadata.Properties[StaticDnBVocabulary.BusinessPartner.DomesticUltimateDuns] = domesticUltimateDuns;
-        metadata.Properties[StaticDnBVocabulary.BusinessPartner.GlobalUltimateDuns] = globalUltimateDuns;
-
+        metadata.Properties[StaticDnBVocabulary.BusinessPartner.DomesticUltimateDuns] = resultItem.Data.organization?.corporateLinkage?.domesticUltimate?.duns;
+        metadata.Properties[StaticDnBVocabulary.BusinessPartner.GlobalUltimateDuns] = resultItem.Data.organization?.corporateLinkage?.globalUltimate?.duns;
 
         //resultItem.Data.organization.telephone
 
         // Business Information
         metadata.Properties[StaticDnBVocabulary.BusinessPartner.PrimaryBusinessName] = resultItem.Data.organization?.primaryName;
-
-        PopulatePrimaryAddress(metadata, resultItem.Data.organization?.primaryAddress);
+        metadata.Properties[StaticDnBVocabulary.BusinessPartner.BusinessEntityTypeDnbCode] = resultItem.Data.organization?.businessEntityType?.dnbCode.PrintIfAvailable();
+        metadata.Properties[StaticDnBVocabulary.BusinessPartner.BusinessEntityTypeDescription] = resultItem.Data.organization?.businessEntityType?.description;
 
         //metadata.Properties[StaticDnBVocabulary.BusinessPartner.WebsiteUrl] = resultItem.Data.organization.websiteAddress.First()..PrintIfAvailable();
 
-        if (resultItem.Data.organization?.industryCodes != null)
-        {
-            foreach (var industryCode in resultItem.Data.organization.industryCodes)
-            {
-                var industryEntityCode = new EntityCode("/IndustrySIC", "DnB", industryCode.code);
-                metadata.OutgoingEdges.Add(new EntityEdge(new EntityReference(request.EntityMetaData.OriginEntityCode), new EntityReference(industryEntityCode), "/IndustrySic"));
-            }
-        }
-
-        metadata.Properties[StaticDnBVocabulary.BusinessPartner.BusinessEntityTypeDnbCode] = resultItem.Data.organization?.businessEntityType?.dnbCode.PrintIfAvailable();
-        metadata.Properties[StaticDnBVocabulary.BusinessPartner.BusinessEntityTypeDescription] = resultItem.Data.organization?.businessEntityType?.description;
+        PopulateIndustryCodes(metadata, resultItem);
     }
 
     public IEnumerable<EntityType> Accepts(IDictionary<string, object> config, IProvider provider) => Accepts(config);
@@ -344,85 +331,46 @@ public class DnBExternalSearchProvider : ExternalSearchProviderBase, IExtendedEn
 
         this.PopulateMetadata(clue.Data.EntityData, resultItem, request);
 
-        //Create all Companies from Ultimate and Global Parents
-        if (resultItem.Data.organization.corporateLinkage?.domesticUltimate?.primaryAddress != null && !string.IsNullOrWhiteSpace(resultItem.Data.organization.corporateLinkage.domesticUltimate?.duns))
-        {
-            var domesticUltimateEntityCode = new EntityCode(request.EntityMetaData.EntityType, "DnB", resultItem.Data.organization.corporateLinkage.domesticUltimate.duns);
-            var domesticUltimateClue = new Clue(domesticUltimateEntityCode, context.Organization);
-
-            //metadata.OutgoingEdges.Add();
-            domesticUltimateClue.Data.EntityData.EntityType = request.EntityMetaData.EntityType;
-            //TODO: add Name
-
-            domesticUltimateClue.Data.EntityData.Name = resultItem.Data.organization.corporateLinkage.domesticUltimate.primaryName;
-            domesticUltimateClue.Data.EntityData.OriginEntityCode = domesticUltimateEntityCode;
-
-            domesticUltimateClue.Data.EntityData.Codes.Add(domesticUltimateEntityCode);
-
-            PopulatePrimaryAddress(domesticUltimateClue.Data.EntityData, resultItem.Data.organization.corporateLinkage.domesticUltimate.primaryAddress);
-
-            yield return domesticUltimateClue;
-        }
-
-        if (resultItem.Data.organization.corporateLinkage?.globalUltimate?.primaryAddress != null && !string.IsNullOrWhiteSpace(resultItem.Data.organization.corporateLinkage.globalUltimate?.duns))
-        {
-            var domesticUltimateEntityCode = new EntityCode(request.EntityMetaData.EntityType, "DnB", resultItem.Data.organization.corporateLinkage.globalUltimate.duns);
-            var domesticUltimateClue = new Clue(domesticUltimateEntityCode, context.Organization);
-
-            //metadata.OutgoingEdges.Add();
-            domesticUltimateClue.Data.EntityData.EntityType = request.EntityMetaData.EntityType;
-            //TODO: add Name
-            domesticUltimateClue.Data.EntityData.Name = resultItem.Data.organization.corporateLinkage.globalUltimate.primaryName;
-            domesticUltimateClue.Data.EntityData.OriginEntityCode = domesticUltimateEntityCode;
-
-            domesticUltimateClue.Data.EntityData.Codes.Add(domesticUltimateEntityCode);
-
-            PopulatePrimaryAddress(domesticUltimateClue.Data.EntityData, resultItem.Data.organization.corporateLinkage.globalUltimate.primaryAddress);
-
-            yield return domesticUltimateClue;
-        }
-
-        //Create all Industry Codes
-        if (resultItem.Data.organization?.industryCodes != null)
-        {
-            foreach (var industryCode in resultItem.Data.organization.industryCodes)
-            {
-                if (industryCode == null) continue;
-                var industryEntityCode = new EntityCode("/IndustrySIC", "DnB", industryCode.code);
-                var industryClue = new Clue(industryEntityCode, context.Organization);
-
-                //metadata.OutgoingEdges.Add();
-                industryClue.Data.EntityData.EntityType = "/IndustrySIC";
-                //TODO: add Name
-                industryClue.Data.EntityData.Name = industryCode.description;
-                industryClue.Data.EntityData.OriginEntityCode = industryEntityCode;
-
-                industryClue.Data.EntityData.Codes.Add(industryEntityCode);
-
-
-                industryClue.Data.EntityData.Properties[StaticDnBVocabulary.Industry.Description] = industryCode.description;
-                industryClue.Data.EntityData.Properties[StaticDnBVocabulary.Industry.TypeDescription] = industryCode.typeDescription;
-                industryClue.Data.EntityData.Properties[StaticDnBVocabulary.Industry.TypeDnBCode] = industryCode.typeDnBCode.PrintIfAvailable();
-                industryClue.Data.EntityData.Properties[StaticDnBVocabulary.Industry.Priority] = industryCode.priority.PrintIfAvailable();
-                industryClue.Data.EntityData.Properties[StaticDnBVocabulary.Industry.Code] = industryCode.code;
-
-                yield return industryClue;
-            }
-        }
-
-        //Create all Senior Principals
-
-        //Create all Curren Principals
-
-        // TODO: If necessary, you can create multiple clues and return them.
-
         yield return clue;
     }
 
-    private void PopulatePrimaryAddress(IEntityMetadata metadata, PrimaryAddress primaryAddress)
+    private void PopulatePrimaryAddresses(IEntityMetadata metadata, IExternalSearchQueryResult<DNBResponse> resultItem)
     {
-        if (primaryAddress == null) return;
+        var domesticUltimateDuns = resultItem.Data.organization?.corporateLinkage?.domesticUltimate?.duns;
+        var globalUltimateDuns = resultItem.Data.organization?.corporateLinkage?.globalUltimate?.duns;
+        var duns = resultItem.Data.organization?.duns;
 
+        if (resultItem.Data.organization?.corporateLinkage?.domesticUltimate?.primaryAddress != null && !string.IsNullOrWhiteSpace(domesticUltimateDuns) && domesticUltimateDuns != duns)
+        {
+            var domesticUltimatePrimaryAddress = resultItem.Data.organization.corporateLinkage.domesticUltimate.primaryAddress;
+
+            metadata.Properties[StaticDnBVocabulary.BusinessPartner.DomesticUltimatePrimaryAddressCountry] = domesticUltimatePrimaryAddress.addressCountry?.name;
+            metadata.Properties[StaticDnBVocabulary.BusinessPartner.DomesticUltimateISO2CountryCode] = domesticUltimatePrimaryAddress.addressCountry?.isoAlpha2Code;
+            metadata.Properties[StaticDnBVocabulary.BusinessPartner.DomesticUltimatePrimaryAddressCountyName] = domesticUltimatePrimaryAddress.addressCounty?.name;
+            metadata.Properties[StaticDnBVocabulary.BusinessPartner.DomesticUltimatePrimaryAddressLocality] = domesticUltimatePrimaryAddress.addressLocality?.name;
+            metadata.Properties[StaticDnBVocabulary.BusinessPartner.DomesticUltimatePrimaryAddressPostalCode] = domesticUltimatePrimaryAddress.postalCode;
+            metadata.Properties[StaticDnBVocabulary.BusinessPartner.DomesticUltimatePrimaryAddressRegionName] = domesticUltimatePrimaryAddress.addressRegion?.name;
+            metadata.Properties[StaticDnBVocabulary.BusinessPartner.DomesticUltimatePrimaryAddressRegionAbbreviatedName] = domesticUltimatePrimaryAddress.addressRegion?.abbreviatedName;
+            metadata.Properties[StaticDnBVocabulary.BusinessPartner.DomesticUltimatePrimaryAddressStreetLine1] = domesticUltimatePrimaryAddress.streetAddress?.line1;
+        }
+
+        if (resultItem.Data.organization?.corporateLinkage?.globalUltimate?.primaryAddress != null && !string.IsNullOrWhiteSpace(globalUltimateDuns) && globalUltimateDuns != duns)
+        {
+            var globalUltimatePrimaryAddress = resultItem.Data.organization.corporateLinkage.globalUltimate.primaryAddress;
+
+            metadata.Properties[StaticDnBVocabulary.BusinessPartner.GlobalUltimatePrimaryAddressCountry] = globalUltimatePrimaryAddress.addressCountry?.name;
+            metadata.Properties[StaticDnBVocabulary.BusinessPartner.GlobalUltimateISO2CountryCode] = globalUltimatePrimaryAddress.addressCountry?.isoAlpha2Code;
+            metadata.Properties[StaticDnBVocabulary.BusinessPartner.GlobalUltimatePrimaryAddressCountyName] = globalUltimatePrimaryAddress.addressCounty?.name;
+            metadata.Properties[StaticDnBVocabulary.BusinessPartner.GlobalUltimatePrimaryAddressLocality] = globalUltimatePrimaryAddress.addressLocality?.name;
+            metadata.Properties[StaticDnBVocabulary.BusinessPartner.GlobalUltimatePrimaryAddressPostalCode] = globalUltimatePrimaryAddress.postalCode;
+            metadata.Properties[StaticDnBVocabulary.BusinessPartner.GlobalUltimatePrimaryAddressRegionName] = globalUltimatePrimaryAddress.addressRegion?.name;
+            metadata.Properties[StaticDnBVocabulary.BusinessPartner.GlobalUltimatePrimaryAddressRegionAbbreviatedName] = globalUltimatePrimaryAddress.addressRegion?.abbreviatedName;
+            metadata.Properties[StaticDnBVocabulary.BusinessPartner.GlobalUltimatePrimaryAddressStreetLine1] = globalUltimatePrimaryAddress.streetAddress?.line1;
+        }
+
+        if (resultItem.Data.organization?.primaryAddress == null) return;
+
+        var primaryAddress = resultItem.Data.organization.primaryAddress;
         metadata.Properties[StaticDnBVocabulary.BusinessPartner.PrimaryAddressCountry] = primaryAddress.addressCountry?.name;
         metadata.Properties[StaticDnBVocabulary.BusinessPartner.ISO2CountryCode] = primaryAddress.addressCountry?.isoAlpha2Code;
         metadata.Properties[StaticDnBVocabulary.BusinessPartner.PrimaryAddressCountyName] = primaryAddress.addressCounty?.name;
@@ -431,7 +379,22 @@ public class DnBExternalSearchProvider : ExternalSearchProviderBase, IExtendedEn
         metadata.Properties[StaticDnBVocabulary.BusinessPartner.PrimaryAddressRegionName] = primaryAddress.addressRegion?.name;
         metadata.Properties[StaticDnBVocabulary.BusinessPartner.PrimaryAddressRegionAbbreviatedName] = primaryAddress.addressRegion?.abbreviatedName;
         metadata.Properties[StaticDnBVocabulary.BusinessPartner.PrimaryAddressStreetLine1] = primaryAddress.streetAddress?.line1;
-        //metadata.Properties[StaticDnBVocabulary.BusinessPartner.PrimaryAddressStreetLine2]         = primaryAddress.streetAddress?.line2;
+        metadata.Properties[StaticDnBVocabulary.BusinessPartner.PrimaryAddressStreetLine2] = primaryAddress.streetAddress?.line2.PrintIfAvailable();
+    }
+
+    private static void PopulateIndustryCodes(IEntityMetadata metadata, IExternalSearchQueryResult<DNBResponse> resultItem)
+    {
+        var industryCodesIndex = 0;
+        foreach (var industryCode in resultItem.Data.organization.industryCodes.Where(_ => resultItem.Data.organization?.industryCodes != null))
+        {
+            metadata.Properties[$"{StaticDnBVocabulary.Industry.KeyPrefix}{StaticDnBVocabulary.Industry.KeySeparator}{industryCodesIndex}.description"] = industryCode.description;
+            metadata.Properties[$"{StaticDnBVocabulary.Industry.KeyPrefix}{StaticDnBVocabulary.Industry.KeySeparator}{industryCodesIndex}.typeDescription"] = industryCode.typeDescription;
+            metadata.Properties[$"{StaticDnBVocabulary.Industry.KeyPrefix}{StaticDnBVocabulary.Industry.KeySeparator}{industryCodesIndex}.typeDnBCode"] = industryCode.typeDnBCode.PrintIfAvailable();
+            metadata.Properties[$"{StaticDnBVocabulary.Industry.KeyPrefix}{StaticDnBVocabulary.Industry.KeySeparator}{industryCodesIndex}.priority"] = industryCode.priority.PrintIfAvailable();
+            metadata.Properties[$"{StaticDnBVocabulary.Industry.KeyPrefix}{StaticDnBVocabulary.Industry.KeySeparator}{industryCodesIndex}.code"] = industryCode.code;
+
+            industryCodesIndex++;
+        }
     }
 
     public IEntityMetadata GetPrimaryEntityMetadata(ExecutionContext context, IExternalSearchQueryResult result, IExternalSearchRequest request, IDictionary<string, object> config, IProvider provider)

--- a/src/ExternalSearch.Providers.Dnb/DnBExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.Dnb/DnBExternalSearchProvider.cs
@@ -352,6 +352,7 @@ public class DnBExternalSearchProvider : ExternalSearchProviderBase, IExtendedEn
             metadata.Properties[StaticDnBVocabulary.BusinessPartner.DomesticUltimatePrimaryAddressRegionName] = domesticUltimatePrimaryAddress.addressRegion?.name;
             metadata.Properties[StaticDnBVocabulary.BusinessPartner.DomesticUltimatePrimaryAddressRegionAbbreviatedName] = domesticUltimatePrimaryAddress.addressRegion?.abbreviatedName;
             metadata.Properties[StaticDnBVocabulary.BusinessPartner.DomesticUltimatePrimaryAddressStreetLine1] = domesticUltimatePrimaryAddress.streetAddress?.line1;
+            metadata.Properties[StaticDnBVocabulary.BusinessPartner.DomesticUltimatePrimaryAddressStreetLine2] = domesticUltimatePrimaryAddress.streetAddress?.line2.PrintIfAvailable();
         }
 
         if (resultItem.Data.organization?.corporateLinkage?.globalUltimate?.primaryAddress != null && !string.IsNullOrWhiteSpace(globalUltimateDuns) && globalUltimateDuns != duns)
@@ -366,6 +367,7 @@ public class DnBExternalSearchProvider : ExternalSearchProviderBase, IExtendedEn
             metadata.Properties[StaticDnBVocabulary.BusinessPartner.GlobalUltimatePrimaryAddressRegionName] = globalUltimatePrimaryAddress.addressRegion?.name;
             metadata.Properties[StaticDnBVocabulary.BusinessPartner.GlobalUltimatePrimaryAddressRegionAbbreviatedName] = globalUltimatePrimaryAddress.addressRegion?.abbreviatedName;
             metadata.Properties[StaticDnBVocabulary.BusinessPartner.GlobalUltimatePrimaryAddressStreetLine1] = globalUltimatePrimaryAddress.streetAddress?.line1;
+            metadata.Properties[StaticDnBVocabulary.BusinessPartner.GlobalUltimatePrimaryAddressStreetLine2] = globalUltimatePrimaryAddress.streetAddress?.line2.PrintIfAvailable();
         }
 
         if (resultItem.Data.organization?.primaryAddress == null) return;
@@ -385,7 +387,7 @@ public class DnBExternalSearchProvider : ExternalSearchProviderBase, IExtendedEn
     private static void PopulateIndustryCodes(IEntityMetadata metadata, IExternalSearchQueryResult<DNBResponse> resultItem)
     {
         var industryCodesIndex = 0;
-        foreach (var industryCode in resultItem.Data.organization.industryCodes.Where(_ => resultItem.Data.organization?.industryCodes != null))
+        foreach (var industryCode in resultItem.Data.organization?.industryCodes ?? Enumerable.Empty<IndustryCode>())
         {
             metadata.Properties[$"{StaticDnBVocabulary.Industry.KeyPrefix}{StaticDnBVocabulary.Industry.KeySeparator}{industryCodesIndex}.description"] = industryCode.description;
             metadata.Properties[$"{StaticDnBVocabulary.Industry.KeyPrefix}{StaticDnBVocabulary.Industry.KeySeparator}{industryCodesIndex}.typeDescription"] = industryCode.typeDescription;

--- a/src/ExternalSearch.Providers.Dnb/Vocabularies/DnBVocabulary.cs
+++ b/src/ExternalSearch.Providers.Dnb/Vocabularies/DnBVocabulary.cs
@@ -19,16 +19,34 @@ public class DnBVocabulary : SimpleVocabulary
             OperatingStatusCode = group.Add(new VocabularyKey(nameof(OperatingStatusCode), VocabularyKeyDataType.Text, VocabularyKeyVisibility.Visible));
             OperatingStatusDescription = group.Add(new VocabularyKey(nameof(OperatingStatusDescription), VocabularyKeyDataType.Text, VocabularyKeyVisibility.Visible));
             ISO2CountryCode = group.Add(new VocabularyKey(nameof(ISO2CountryCode), VocabularyKeyDataType.Text, VocabularyKeyVisibility.Visible));
+            GlobalUltimateISO2CountryCode = group.Add(new VocabularyKey(nameof(GlobalUltimateISO2CountryCode), VocabularyKeyDataType.Text, VocabularyKeyVisibility.Visible));
+            DomesticUltimateISO2CountryCode = group.Add(new VocabularyKey(nameof(DomesticUltimateISO2CountryCode), VocabularyKeyDataType.Text, VocabularyKeyVisibility.Visible));
             PrimaryBusinessName = group.Add(new VocabularyKey(nameof(PrimaryBusinessName), VocabularyKeyDataType.Text, VocabularyKeyVisibility.Visible));
             PrimaryAddressCountry = group.Add(new VocabularyKey(nameof(PrimaryAddressCountry), VocabularyKeyDataType.Text, VocabularyKeyVisibility.Visible));
             PrimaryAddressCountyName = group.Add(new VocabularyKey(nameof(PrimaryAddressCountyName), VocabularyKeyDataType.Text, VocabularyKeyVisibility.Visible));
             PrimaryAddressLocality = group.Add(new VocabularyKey(nameof(PrimaryAddressLocality), VocabularyKeyDataType.Text, VocabularyKeyVisibility.Visible));
             PrimaryAddressPostalCode = group.Add(new VocabularyKey(nameof(PrimaryAddressPostalCode), VocabularyKeyDataType.Text, VocabularyKeyVisibility.Visible));
-            PrimaryAddressPostalCodeExtension = group.Add(new VocabularyKey(nameof(PrimaryAddressPostalCodeExtension), VocabularyKeyDataType.Text, VocabularyKeyVisibility.Visible));
             PrimaryAddressRegionAbbreviatedName = group.Add(new VocabularyKey(nameof(PrimaryAddressRegionAbbreviatedName), VocabularyKeyDataType.Text, VocabularyKeyVisibility.Visible));
             PrimaryAddressRegionName = group.Add(new VocabularyKey(nameof(PrimaryAddressRegionName), VocabularyKeyDataType.Text, VocabularyKeyVisibility.Visible));
             PrimaryAddressStreetLine1 = group.Add(new VocabularyKey(nameof(PrimaryAddressStreetLine1), VocabularyKeyDataType.Text, VocabularyKeyVisibility.Visible));
             PrimaryAddressStreetLine2 = group.Add(new VocabularyKey(nameof(PrimaryAddressStreetLine2), VocabularyKeyDataType.Text, VocabularyKeyVisibility.Visible));
+            GlobalUltimatePrimaryAddressCountry = group.Add(new VocabularyKey(nameof(GlobalUltimatePrimaryAddressCountry), VocabularyKeyDataType.Text, VocabularyKeyVisibility.Visible));
+            GlobalUltimatePrimaryAddressCountyName = group.Add(new VocabularyKey(nameof(GlobalUltimatePrimaryAddressCountyName), VocabularyKeyDataType.Text, VocabularyKeyVisibility.Visible));
+            GlobalUltimatePrimaryAddressLocality = group.Add(new VocabularyKey(nameof(GlobalUltimatePrimaryAddressLocality), VocabularyKeyDataType.Text, VocabularyKeyVisibility.Visible));
+            GlobalUltimatePrimaryAddressPostalCode = group.Add(new VocabularyKey(nameof(GlobalUltimatePrimaryAddressPostalCode), VocabularyKeyDataType.Text, VocabularyKeyVisibility.Visible));
+            PrimaryAddressPostalCodeExtension = group.Add(new VocabularyKey(nameof(PrimaryAddressPostalCodeExtension), VocabularyKeyDataType.Text, VocabularyKeyVisibility.Visible));
+            GlobalUltimatePrimaryAddressRegionAbbreviatedName = group.Add(new VocabularyKey(nameof(GlobalUltimatePrimaryAddressRegionAbbreviatedName), VocabularyKeyDataType.Text, VocabularyKeyVisibility.Visible));
+            GlobalUltimatePrimaryAddressRegionName = group.Add(new VocabularyKey(nameof(GlobalUltimatePrimaryAddressRegionName), VocabularyKeyDataType.Text, VocabularyKeyVisibility.Visible));
+            GlobalUltimatePrimaryAddressStreetLine1 = group.Add(new VocabularyKey(nameof(GlobalUltimatePrimaryAddressStreetLine1), VocabularyKeyDataType.Text, VocabularyKeyVisibility.Visible));
+            GlobalUltimatePrimaryAddressStreetLine2 = group.Add(new VocabularyKey(nameof(GlobalUltimatePrimaryAddressStreetLine2), VocabularyKeyDataType.Text, VocabularyKeyVisibility.Visible));
+            DomesticUltimatePrimaryAddressCountry = group.Add(new VocabularyKey(nameof(DomesticUltimatePrimaryAddressCountry), VocabularyKeyDataType.Text, VocabularyKeyVisibility.Visible));
+            DomesticUltimatePrimaryAddressCountyName = group.Add(new VocabularyKey(nameof(DomesticUltimatePrimaryAddressCountyName), VocabularyKeyDataType.Text, VocabularyKeyVisibility.Visible));
+            DomesticUltimatePrimaryAddressLocality = group.Add(new VocabularyKey(nameof(DomesticUltimatePrimaryAddressLocality), VocabularyKeyDataType.Text, VocabularyKeyVisibility.Visible));
+            DomesticUltimatePrimaryAddressPostalCode = group.Add(new VocabularyKey(nameof(DomesticUltimatePrimaryAddressPostalCode), VocabularyKeyDataType.Text, VocabularyKeyVisibility.Visible));
+            DomesticUltimatePrimaryAddressRegionAbbreviatedName = group.Add(new VocabularyKey(nameof(DomesticUltimatePrimaryAddressRegionAbbreviatedName), VocabularyKeyDataType.Text, VocabularyKeyVisibility.Visible));
+            DomesticUltimatePrimaryAddressRegionName = group.Add(new VocabularyKey(nameof(DomesticUltimatePrimaryAddressRegionName), VocabularyKeyDataType.Text, VocabularyKeyVisibility.Visible));
+            DomesticUltimatePrimaryAddressStreetLine1 = group.Add(new VocabularyKey(nameof(DomesticUltimatePrimaryAddressStreetLine1), VocabularyKeyDataType.Text, VocabularyKeyVisibility.Visible));
+            DomesticUltimatePrimaryAddressStreetLine2 = group.Add(new VocabularyKey(nameof(DomesticUltimatePrimaryAddressStreetLine2), VocabularyKeyDataType.Text, VocabularyKeyVisibility.Visible));
             WebsiteUrl = group.Add(new VocabularyKey(nameof(WebsiteUrl), VocabularyKeyDataType.Text, VocabularyKeyVisibility.Visible));
             RegistrationNumber2 = group.Add(new VocabularyKey(nameof(RegistrationNumber2), VocabularyKeyDataType.Text, VocabularyKeyVisibility.Visible));
             DunsControlStatusFullReportDate = group.Add(new VocabularyKey(nameof(DunsControlStatusFullReportDate), VocabularyKeyDataType.Text, VocabularyKeyVisibility.Visible));
@@ -49,20 +67,38 @@ public class DnBVocabulary : SimpleVocabulary
     public VocabularyKey Duns { get; protected set; }
     public VocabularyKey MatchConfidenceCode { get; protected set; }
     public VocabularyKey PrimaryBusinessName { get; protected set; }
-    public VocabularyKey ISO2CountryCode { get; protected set; }
     public VocabularyKey DomesticUltimateDuns { get; protected set; }
     public VocabularyKey GlobalUltimateDuns { get; protected set; }
     public VocabularyKey OperatingStatusCode { get; protected set; }
     public VocabularyKey OperatingStatusDescription { get; protected set; }
+    public VocabularyKey ISO2CountryCode { get; protected set; }
     public VocabularyKey PrimaryAddressCountry { get; protected set; }
     public VocabularyKey PrimaryAddressCountyName { get; protected set; }
     public VocabularyKey PrimaryAddressLocality { get; protected set; }
     public VocabularyKey PrimaryAddressRegionAbbreviatedName { get; protected set; }
     public VocabularyKey PrimaryAddressRegionName { get; protected set; }
     public VocabularyKey PrimaryAddressPostalCode { get; protected set; }
-    public VocabularyKey PrimaryAddressPostalCodeExtension { get; protected set; }
     public VocabularyKey PrimaryAddressStreetLine1 { get; protected set; }
     public VocabularyKey PrimaryAddressStreetLine2 { get; protected set; }
+    public VocabularyKey GlobalUltimateISO2CountryCode { get; protected set; }
+    public VocabularyKey GlobalUltimatePrimaryAddressCountry { get; protected set; }
+    public VocabularyKey GlobalUltimatePrimaryAddressCountyName { get; protected set; }
+    public VocabularyKey GlobalUltimatePrimaryAddressLocality { get; protected set; }
+    public VocabularyKey GlobalUltimatePrimaryAddressRegionAbbreviatedName { get; protected set; }
+    public VocabularyKey GlobalUltimatePrimaryAddressRegionName { get; protected set; }
+    public VocabularyKey GlobalUltimatePrimaryAddressPostalCode { get; protected set; }
+    public VocabularyKey PrimaryAddressPostalCodeExtension { get; protected set; }
+    public VocabularyKey GlobalUltimatePrimaryAddressStreetLine1 { get; protected set; }
+    public VocabularyKey GlobalUltimatePrimaryAddressStreetLine2 { get; protected set; }
+    public VocabularyKey DomesticUltimateISO2CountryCode { get; protected set; }
+    public VocabularyKey DomesticUltimatePrimaryAddressCountry { get; protected set; }
+    public VocabularyKey DomesticUltimatePrimaryAddressCountyName { get; protected set; }
+    public VocabularyKey DomesticUltimatePrimaryAddressLocality { get; protected set; }
+    public VocabularyKey DomesticUltimatePrimaryAddressRegionAbbreviatedName { get; protected set; }
+    public VocabularyKey DomesticUltimatePrimaryAddressRegionName { get; protected set; }
+    public VocabularyKey DomesticUltimatePrimaryAddressPostalCode { get; protected set; }
+    public VocabularyKey DomesticUltimatePrimaryAddressStreetLine1 { get; protected set; }
+    public VocabularyKey DomesticUltimatePrimaryAddressStreetLine2 { get; protected set; }
     public VocabularyKey WebsiteUrl { get; protected set; }
     public VocabularyKey RegistrationNumber2 { get; protected set; }
     public VocabularyKey DunsControlStatusFullReportDate { get; protected set; }


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#54836](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/54836)

Now the GlobalUltimate, DomesticUltimate and IndustryCodes clues are being converted into properties, so less clues created and less rows appeared in Preview tab. Should be no more golden records merging together due to similar industryCodes clues that produced by different golden record.

<img width="1912" height="942" alt="image" src="https://github.com/user-attachments/assets/07ec9917-b710-4895-88f1-641dffa706a4" />

## How has it been tested? <!-- Remove if not needed -->
Manually in local


