### PR TITLE
feat: Include more results and allow user to decide results returned

### DIFF
--- a/docs/4.6.1-release-notes.md
+++ b/docs/4.6.1-release-notes.md
@@ -1,6 +1,8 @@
 ### Features
 - Display help text on the Enricher Configuration page
 - Include confidence score and more organization properties from DnB API
+- Include NumberOfEmployees and YearlyRevenue
+- Allow user to decide which IndustryCodes and RegistrationNumbers will be returned in the result. 
 
 ### Fixes
 - Convert globalUltimate, domesticUltimate and industryCodes clues into properties to solve merging issues due to many identical clues

--- a/src/ExternalSearch.Providers.Dnb/DnBConstants.cs
+++ b/src/ExternalSearch.Providers.Dnb/DnBConstants.cs
@@ -107,7 +107,10 @@ public static class DnBConstants
             IsRequired = false,
             Name = KeyName.IndustryCodesKey,
             Help = "The TypeDnBCode values that will determine which industry codes are returned in the result. (e.g., 19295,37788)",
-            ValidationRules = [new Dictionary<string, string> { { "regex", "[^0-9,]" }, { "message", "Non-numeric values are not allowed." } }]
+            ValidationRules = new List<Dictionary<string, string>>
+            {
+                new() { { "regex", "[^0-9,]" }, { "message", "Non-numeric values are not allowed." } }
+            }
         },
         new()
         {
@@ -116,7 +119,10 @@ public static class DnBConstants
             IsRequired = false,
             Name = KeyName.RegistrationNumbersKey,
             Help = "The TypeDnBCode values that will determine which registration numbers are returned in the result (e.g., 12897,12444)",
-            ValidationRules = [new Dictionary<string, string> { { "regex", "[^0-9,]" }, { "message", "Non-numeric values are not allowed." } }]
+            ValidationRules = new List<Dictionary<string, string>>
+            {
+                new() { { "regex", "[^0-9,]" }, { "message", "Non-numeric values are not allowed." } }
+            }
         },
         // Match and Append 
         new()

--- a/src/ExternalSearch.Providers.Dnb/DnBConstants.cs
+++ b/src/ExternalSearch.Providers.Dnb/DnBConstants.cs
@@ -50,8 +50,9 @@ public static class DnBConstants
         public const string AcceptedEntityType = "acceptedEntityType";
         public const string DunsNumberKey = "dunsNumberKey";
         public const string OrgNameKey = "orgNameKey";
-        public const string OrgAddressKey = "orgAddressKey";
         public const string OrgCountryCodeKey = "orgCountryCodeKey";
+        public const string RegistrationNumbersKey = "registrationNumbersKey";
+        public const string IndustryCodesKey = "industryCodesKey";
         public const string AuthUrl = "DNB_AUTH_URL";
         public const string AuthKey = "DNB_AUTH_KEY";
         public const string AuthSecret = "DNB_AUTH_SECRET";
@@ -80,13 +81,6 @@ public static class DnBConstants
     {
         new()
         {
-            DisplayName = "Organization Name Vocabulary Key",
-            Type = "vocabularyKeySelector",
-            IsRequired = false,
-            Name = KeyName.OrgNameKey
-        },
-        new()
-        {
             DisplayName = "DUNS Vocabulary Key",
             Type = "vocabularyKeySelector",
             IsRequired = false,
@@ -94,10 +88,10 @@ public static class DnBConstants
         },
         new()
         {
-            DisplayName = "Organization Address Vocabulary Key",
+            DisplayName = "Organization Name Vocabulary Key",
             Type = "vocabularyKeySelector",
             IsRequired = false,
-            Name = KeyName.OrgAddressKey
+            Name = KeyName.OrgNameKey
         },
         new()
         {
@@ -105,6 +99,24 @@ public static class DnBConstants
             Type = "vocabularyKeySelector",
             IsRequired = false,
             Name = KeyName.OrgCountryCodeKey
+        },
+        new()
+        {
+            DisplayName = "Industry Code Types",
+            Type = "input",
+            IsRequired = false,
+            Name = KeyName.IndustryCodesKey,
+            Help = "The TypeDnBCode values that will determine which industry codes are returned in the result. (e.g., 19295,37788)",
+            ValidationRules = [new Dictionary<string, string> { { "regex", "^[^0-9,]" }, { "message", "Non-numeric values are not allowed." } }]
+        },
+        new()
+        {
+            DisplayName = "Registration Number Types",
+            Type = "input",
+            IsRequired = false,
+            Name = KeyName.RegistrationNumbersKey,
+            Help = "The TypeDnBCode values that will determine which registration numbers are returned in the result (e.g., 12897,13068)",
+            ValidationRules = [new Dictionary<string, string> { { "regex", "[^0-9,]" }, { "message", "Non-numeric values are not allowed." } }]
         },
         // Match and Append 
         new()

--- a/src/ExternalSearch.Providers.Dnb/DnBConstants.cs
+++ b/src/ExternalSearch.Providers.Dnb/DnBConstants.cs
@@ -107,7 +107,7 @@ public static class DnBConstants
             IsRequired = false,
             Name = KeyName.IndustryCodesKey,
             Help = "The TypeDnBCode values that will determine which industry codes are returned in the result. (e.g., 19295,37788)",
-            ValidationRules = [new Dictionary<string, string> { { "regex", "^[^0-9,]" }, { "message", "Non-numeric values are not allowed." } }]
+            ValidationRules = [new Dictionary<string, string> { { "regex", "[^0-9,]" }, { "message", "Non-numeric values are not allowed." } }]
         },
         new()
         {
@@ -115,7 +115,7 @@ public static class DnBConstants
             Type = "input",
             IsRequired = false,
             Name = KeyName.RegistrationNumbersKey,
-            Help = "The TypeDnBCode values that will determine which registration numbers are returned in the result (e.g., 12897,13068)",
+            Help = "The TypeDnBCode values that will determine which registration numbers are returned in the result (e.g., 12897,12444)",
             ValidationRules = [new Dictionary<string, string> { { "regex", "[^0-9,]" }, { "message", "Non-numeric values are not allowed." } }]
         },
         // Match and Append 

--- a/src/ExternalSearch.Providers.Dnb/DnBExternalSearchJobData.cs
+++ b/src/ExternalSearch.Providers.Dnb/DnBExternalSearchJobData.cs
@@ -10,8 +10,9 @@ public class DnBExternalSearchJobData : CrawlJobData
         AcceptedEntityType = GetValue<string>(configuration, DnBConstants.KeyName.AcceptedEntityType);
         OrgNameKey = GetValue<string>(configuration, DnBConstants.KeyName.OrgNameKey);
         DunsNumberKey = GetValue<string>(configuration, DnBConstants.KeyName.DunsNumberKey);
-        OrgAddressKey = GetValue<string>(configuration, DnBConstants.KeyName.OrgAddressKey);
         OrgCountryCodeKey = GetValue<string>(configuration, DnBConstants.KeyName.OrgCountryCodeKey);
+        IndustryCodesKey = GetValue<string>(configuration, DnBConstants.KeyName.IndustryCodesKey);
+        RegistrationNumbersKey = GetValue<string>(configuration, DnBConstants.KeyName.RegistrationNumbersKey);
         AuthUrl = GetValue<string>(configuration, DnBConstants.KeyName.AuthUrl);
         AuthKey = GetValue<string>(configuration, DnBConstants.KeyName.AuthKey);
         AuthSecret = GetValue<string>(configuration, DnBConstants.KeyName.AuthSecret);
@@ -29,8 +30,9 @@ public class DnBExternalSearchJobData : CrawlJobData
             { DnBConstants.KeyName.AcceptedEntityType, AcceptedEntityType },
             { DnBConstants.KeyName.OrgNameKey, OrgNameKey },
             { DnBConstants.KeyName.DunsNumberKey, DunsNumberKey },
-            { DnBConstants.KeyName.OrgAddressKey, OrgAddressKey },
             { DnBConstants.KeyName.OrgCountryCodeKey, OrgCountryCodeKey },
+            { DnBConstants.KeyName.IndustryCodesKey, IndustryCodesKey},
+            { DnBConstants.KeyName.RegistrationNumbersKey, RegistrationNumbersKey},
             { DnBConstants.KeyName.AuthUrl, AuthUrl },
             { DnBConstants.KeyName.AuthKey, AuthKey },
             { DnBConstants.KeyName.AuthSecret, AuthSecret },
@@ -45,8 +47,9 @@ public class DnBExternalSearchJobData : CrawlJobData
     public string AcceptedEntityType { get; set; }
     public string OrgNameKey { get; set; }
     public string DunsNumberKey { get; set; }
-    public string OrgAddressKey { get; set; }
     public string OrgCountryCodeKey { get; set; }
+    public string IndustryCodesKey { get; set; }
+    public string RegistrationNumbersKey { get; set; }
     public string AuthUrl { get; set; }
     public string AuthKey { get; set; }
     public string AuthSecret { get; set; }

--- a/src/ExternalSearch.Providers.Dnb/DnBExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.Dnb/DnBExternalSearchProvider.cs
@@ -415,8 +415,12 @@ public class DnBExternalSearchProvider : ExternalSearchProviderBase, IExtendedEn
         metadata.Properties[StaticDnBVocabulary.BusinessPartner.BusinessEntityTypeDescription] = resultItem.Data.organization?.businessEntityType?.description;
 
         // Trade Style Names
-        var tradeStyleNames = resultItem.Data.organization?.tradeStyleNames?.Select(t => t.name).Where(n => !string.IsNullOrEmpty(n));
-        metadata.Properties[StaticDnBVocabulary.BusinessPartner.TradeStyleNames] = string.Join(" | ", tradeStyleNames);
+        var tradeStyleNameValues = resultItem.Data.organization?.tradeStyleNames?.Select(t => t.name).Where(n => !string.IsNullOrEmpty(n));
+        var tradeStyleNames = tradeStyleNameValues?.ToList();
+        if (tradeStyleNameValues != null && tradeStyleNames.Any())
+        {
+            metadata.Properties[StaticDnBVocabulary.BusinessPartner.TradeStyleNames] = string.Join(" | ", tradeStyleNames);
+        }
 
         // WebsiteAddress
         var website = resultItem.Data.organization?.websiteAddress?.FirstOrDefault();
@@ -427,14 +431,14 @@ public class DnBExternalSearchProvider : ExternalSearchProviderBase, IExtendedEn
 
         // Telephone
         var telephone = resultItem.Data.organization?.telephone?.FirstOrDefault();
-        if (telephone != null)
+        if (telephone != null && !string.IsNullOrEmpty(telephone.isdCode) && !string.IsNullOrEmpty(telephone.telephoneNumber))
         {
             metadata.Properties[StaticDnBVocabulary.BusinessPartner.Telephone] = $"+{telephone.isdCode} {telephone.telephoneNumber}";
         }
 
         // Fax
         var fax = resultItem.Data.organization?.fax?.FirstOrDefault();
-        if (fax != null)
+        if (fax != null && !string.IsNullOrEmpty(fax.isdCode) && !string.IsNullOrEmpty(fax.faxNumber))
         {
             metadata.Properties[StaticDnBVocabulary.BusinessPartner.Fax] = $"+{fax.isdCode} {fax.faxNumber}";
         }
@@ -487,9 +491,17 @@ public class DnBExternalSearchProvider : ExternalSearchProviderBase, IExtendedEn
         metadata.Properties[StaticDnBVocabulary.BusinessPartner.DomesticUltimateNumberOfEmployees] = resultItem.Data.organization?.corporateLinkage?.domesticUltimate?.numberOfEmployees?.FirstOrDefault()?.value.PrintIfAvailable();
 
         // Yearly Revenue
-        metadata.Properties[StaticDnBVocabulary.BusinessPartner.YearlyRevenue] = $"{resultItem.Data.organization?.financials?.FirstOrDefault()?.yearlyRevenue?.FirstOrDefault()?.value} {resultItem.Data.organization?.financials?.FirstOrDefault()?.yearlyRevenue?.FirstOrDefault()?.currency}";
-        metadata.Properties[StaticDnBVocabulary.BusinessPartner.GlobalUltimateYearlyRevenue] = $"{resultItem.Data.organization?.corporateLinkage?.globalUltimate?.financials?.FirstOrDefault()?.yearlyRevenue?.FirstOrDefault()?.value} {resultItem.Data.organization?.corporateLinkage?.globalUltimate?.financials?.FirstOrDefault()?.yearlyRevenue?.FirstOrDefault()?.currency}";
-        metadata.Properties[StaticDnBVocabulary.BusinessPartner.DomesticUltimateYearlyRevenue] = $"{resultItem.Data.organization?.corporateLinkage?.domesticUltimate?.financials?.FirstOrDefault()?.yearlyRevenue?.FirstOrDefault()?.value} {resultItem.Data.organization?.corporateLinkage?.domesticUltimate?.financials?.FirstOrDefault()?.yearlyRevenue?.FirstOrDefault()?.currency}";
+        var orgFinancial = resultItem.Data.organization?.financials?.FirstOrDefault();
+        var orgYearlyRevenue = orgFinancial?.yearlyRevenue?.FirstOrDefault();
+        metadata.Properties[StaticDnBVocabulary.BusinessPartner.YearlyRevenue] = orgYearlyRevenue != null && !string.IsNullOrEmpty(orgYearlyRevenue.currency) ? $"{orgYearlyRevenue.value} {orgYearlyRevenue.currency}" : null;
+        
+        var globalUltimateFinancial = resultItem.Data.organization?.globalUltimate?.financials?.FirstOrDefault();
+        var globalUltimateYearlyRevenue = globalUltimateFinancial?.yearlyRevenue?.FirstOrDefault();
+        metadata.Properties[StaticDnBVocabulary.BusinessPartner.GlobalUltimateYearlyRevenue] = globalUltimateYearlyRevenue != null && !string.IsNullOrEmpty(globalUltimateYearlyRevenue.currency) ? $"{globalUltimateYearlyRevenue.value} {globalUltimateYearlyRevenue.currency}" : null;
+        
+        var domesticUltimateFinancial = resultItem.Data.organization?.domesticUltimate?.financials?.FirstOrDefault();
+        var domesticUltimateYearlyRevenue = domesticUltimateFinancial?.yearlyRevenue?.FirstOrDefault();
+        metadata.Properties[StaticDnBVocabulary.BusinessPartner.DomesticUltimateYearlyRevenue] = domesticUltimateYearlyRevenue != null && !string.IsNullOrEmpty(domesticUltimateYearlyRevenue.currency) ? $"{domesticUltimateYearlyRevenue.value} {domesticUltimateYearlyRevenue.currency}" : null;
     }
 
     private static void PopulateIndustryCodes(IEntityMetadata metadata, IExternalSearchQueryResult<DNBResponse> resultItem, DnBExternalSearchJobData jobData)

--- a/src/ExternalSearch.Providers.Dnb/DnBExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.Dnb/DnBExternalSearchProvider.cs
@@ -176,15 +176,6 @@ public class DnBExternalSearchProvider : ExternalSearchProviderBase, IExtendedEn
                 throw new ApplicationException("Could not execute external search query - DnB returned empty organization");
             }
 
-            // Not using industry codes from extended match API
-            if (data.embeddedProduct?.organization != null)
-            {
-                if (organization.industryCodes != null && organization.industryCodes.Any())
-                {
-                    organization.industryCodes.Clear();
-                }
-            }
-
             data.organization = organization;
             yield return new ExternalSearchQueryResult<DNBResponse>(query, data);
             yield break;
@@ -218,11 +209,11 @@ public class DnBExternalSearchProvider : ExternalSearchProviderBase, IExtendedEn
         return responseContent.AccessToken;
     }
 
-    private IEntityMetadata CreateMetadata(IExternalSearchQueryResult<DNBResponse> resultItem, IExternalSearchRequest request)
+    private IEntityMetadata CreateMetadata(IExternalSearchQueryResult<DNBResponse> resultItem, IExternalSearchRequest request, DnBExternalSearchJobData jobData)
     {
         var metadata = new EntityMetadataPart();
 
-        this.PopulateMetadata(metadata, resultItem, request);
+        this.PopulateMetadata(metadata, resultItem, request, jobData);
 
         return metadata;
     }
@@ -239,7 +230,7 @@ public class DnBExternalSearchProvider : ExternalSearchProviderBase, IExtendedEn
         return CodeOrigin.CluedIn.CreateSpecific("DnB");
     }
 
-    private void PopulateMetadata(IEntityMetadata metadata, IExternalSearchQueryResult<DNBResponse> resultItem, IExternalSearchRequest request)
+    private void PopulateMetadata(IEntityMetadata metadata, IExternalSearchQueryResult<DNBResponse> resultItem, IExternalSearchRequest request, DnBExternalSearchJobData jobData)
     {
         var code = this.GetOriginEntityCode(resultItem, request, request.Queries.FirstOrDefault());
         //var firstMatch = resultItem.Data.matchCandidates[0];
@@ -252,9 +243,9 @@ public class DnBExternalSearchProvider : ExternalSearchProviderBase, IExtendedEn
 
         PopulatePrimaryAddresses(metadata, resultItem);
 
-        PopulateOrganizationInfo(metadata, resultItem);
+        PopulateOrganizationInfo(metadata, resultItem, jobData);
 
-        PopulateIndustryCodes(metadata, resultItem);
+        PopulateIndustryCodes(metadata, resultItem, jobData);
 
         PopulateConfidenceScore(metadata, resultItem);
     }
@@ -298,8 +289,9 @@ public class DnBExternalSearchProvider : ExternalSearchProviderBase, IExtendedEn
         var resultItem = result.As<DNBResponse>();
         var code = this.GetOriginEntityCode(resultItem, request, query);
         var clue = new Clue(code, context.Organization);
+        var jobData = new DnBExternalSearchJobData(config);
 
-        this.PopulateMetadata(clue.Data.EntityData, resultItem, request);
+        this.PopulateMetadata(clue.Data.EntityData, resultItem, request, jobData);
 
         yield return clue;
     }
@@ -386,7 +378,7 @@ public class DnBExternalSearchProvider : ExternalSearchProviderBase, IExtendedEn
         metadata.Properties[StaticDnBVocabulary.BusinessPartner.PrimaryAddressStreetLine2] = primaryAddress.streetAddress?.line2.PrintIfAvailable();
     }
 
-    private static void PopulateOrganizationInfo(IEntityMetadata metadata, IExternalSearchQueryResult<DNBResponse> resultItem)
+    private static void PopulateOrganizationInfo(IEntityMetadata metadata, IExternalSearchQueryResult<DNBResponse> resultItem, DnBExternalSearchJobData jobData)
     {
         if (resultItem.Data.organization?.dunsControlStatus != null)
         {
@@ -423,65 +415,50 @@ public class DnBExternalSearchProvider : ExternalSearchProviderBase, IExtendedEn
         metadata.Properties[StaticDnBVocabulary.BusinessPartner.BusinessEntityTypeDescription] = resultItem.Data.organization?.businessEntityType?.description;
 
         // Trade Style Names
-        var tradeStyleNameIndex = 0;
-        foreach (var tradeStyleName in resultItem.Data.organization?.tradeStyleNames ?? Enumerable.Empty<TradeStyleName>())
-        {
-            metadata.Properties[$"{StaticDnBVocabulary.TradeStyleNames.KeyPrefix}{StaticDnBVocabulary.TradeStyleNames.KeySeparator}{tradeStyleNameIndex}.name"] = tradeStyleName.name;
-            metadata.Properties[$"{StaticDnBVocabulary.TradeStyleNames.KeyPrefix}{StaticDnBVocabulary.TradeStyleNames.KeySeparator}{tradeStyleNameIndex}.priority"] = tradeStyleName.priority.PrintIfAvailable();
-
-            tradeStyleNameIndex++;
-        }
+        var tradeStyleNames = resultItem.Data.organization?.tradeStyleNames?.Select(t => t.name).Where(n => !string.IsNullOrEmpty(n)) ?? [];
+        metadata.Properties[StaticDnBVocabulary.BusinessPartner.TradeStyleNames] = string.Join(" | ", tradeStyleNames);
 
         // WebsiteAddress
-        var websiteAddressIndex = 0;
-        foreach (var websiteAddress in resultItem.Data.organization?.websiteAddress ?? Enumerable.Empty<WebsiteAddress>())
+        var website = resultItem.Data.organization?.websiteAddress?.FirstOrDefault();
+        if (website != null)
         {
-            metadata.Properties[$"{StaticDnBVocabulary.WebsiteAddress.KeyPrefix}{StaticDnBVocabulary.WebsiteAddress.KeySeparator}{websiteAddressIndex}.url"] = websiteAddress.url;
-            metadata.Properties[$"{StaticDnBVocabulary.WebsiteAddress.KeyPrefix}{StaticDnBVocabulary.WebsiteAddress.KeySeparator}{websiteAddressIndex}.domainName"] = websiteAddress.domainName;
-
-            websiteAddressIndex++;
+            metadata.Properties[StaticDnBVocabulary.BusinessPartner.WebsiteUrl] = website?.url;
         }
 
         // Telephone
-        var telephoneIndex = 0;
-        foreach (var telephone in resultItem.Data.organization?.telephone ?? Enumerable.Empty<Telephone>())
+        var telephone = resultItem.Data.organization?.telephone?.FirstOrDefault();
+        if (telephone != null)
         {
-            metadata.Properties[$"{StaticDnBVocabulary.Telephone.KeyPrefix}{StaticDnBVocabulary.Telephone.KeySeparator}{telephoneIndex}.telephoneNumber"] = telephone.telephoneNumber;
-            metadata.Properties[$"{StaticDnBVocabulary.Telephone.KeyPrefix}{StaticDnBVocabulary.Telephone.KeySeparator}{telephoneIndex}.isdCode"] = telephone.isdCode;
-
-            telephoneIndex++;
+            metadata.Properties[StaticDnBVocabulary.BusinessPartner.Telephone] = $"+{telephone.isdCode} {telephone.telephoneNumber}";
         }
 
         // Fax
-        var faxIndex = 0;
-        foreach (var fax in resultItem.Data.organization?.fax ?? Enumerable.Empty<Fax>())
+        var fax = resultItem.Data.organization?.fax?.FirstOrDefault();
+        if (fax != null)
         {
-            metadata.Properties[$"{StaticDnBVocabulary.Fax.KeyPrefix}{StaticDnBVocabulary.Fax.KeySeparator}{faxIndex}.faxNumber"] = fax.faxNumber;
-            metadata.Properties[$"{StaticDnBVocabulary.Fax.KeyPrefix}{StaticDnBVocabulary.Fax.KeySeparator}{faxIndex}.isdCode"] = fax.isdCode;
-
-            faxIndex++;
+            metadata.Properties[StaticDnBVocabulary.BusinessPartner.Fax] = $"+{fax?.isdCode} {fax?.faxNumber}";
         }
 
         // Stock Exchanges
-        var stockExchangesIndex = 0;
-        foreach (var stockExchange in resultItem.Data.organization?.stockExchanges ?? Enumerable.Empty<StockExchange>())
+        var primaryStockExchange = resultItem.Data.organization?.stockExchanges?.FirstOrDefault(x => x.isPrimary == true);
+        if (primaryStockExchange != null)
         {
-            metadata.Properties[$"{StaticDnBVocabulary.StockExchanges.KeyPrefix}{StaticDnBVocabulary.StockExchanges.KeySeparator}{stockExchangesIndex}.tickerName"] = stockExchange.tickerName;
-            metadata.Properties[$"{StaticDnBVocabulary.StockExchanges.KeyPrefix}{StaticDnBVocabulary.StockExchanges.KeySeparator}{stockExchangesIndex}.exchangeName.description"] = stockExchange.exchangeName?.description;
-            metadata.Properties[$"{StaticDnBVocabulary.StockExchanges.KeyPrefix}{StaticDnBVocabulary.StockExchanges.KeySeparator}{stockExchangesIndex}.exchangeCountry.exchangeCountry"] = stockExchange.exchangeCountry?.isoAlpha2Code;
-
-            stockExchangesIndex++;
+            metadata.Properties[StaticDnBVocabulary.BusinessPartner.StockExchangeTickerName] = primaryStockExchange.tickerName;
+            metadata.Properties[StaticDnBVocabulary.BusinessPartner.StockExchangeName] = primaryStockExchange.exchangeName?.description;
+            metadata.Properties[StaticDnBVocabulary.BusinessPartner.StockExchangeCountryCode] = primaryStockExchange.exchangeCountry?.isoAlpha2Code;
         }
 
         // Registration Numbers
+        var selectedRegistrationNumberTypes = !string.IsNullOrWhiteSpace(jobData.RegistrationNumbersKey) ? jobData.RegistrationNumbersKey.Split(",") : [];
+        var registrationNumbers = resultItem.Data.organization?.registrationNumbers.Where(x => x.typeDnBCode > 0 && selectedRegistrationNumberTypes.Contains(x.typeDnBCode.ToString()));
         var registrationNumbersIndex = 0;
-        foreach (var registrationNumbers in resultItem.Data.organization?.registrationNumbers ?? Enumerable.Empty<RegistrationNumber>())
+        foreach (var registrationNumber in registrationNumbers ?? [])
         {
-            metadata.Properties[$"{StaticDnBVocabulary.RegistrationNumbers.KeyPrefix}{StaticDnBVocabulary.RegistrationNumbers.KeySeparator}{registrationNumbersIndex}.registrationNumber"] = registrationNumbers.registrationNumber;
-            metadata.Properties[$"{StaticDnBVocabulary.RegistrationNumbers.KeyPrefix}{StaticDnBVocabulary.RegistrationNumbers.KeySeparator}{registrationNumbersIndex}.typeDescription"] = registrationNumbers.typeDescription;
-            metadata.Properties[$"{StaticDnBVocabulary.RegistrationNumbers.KeyPrefix}{StaticDnBVocabulary.RegistrationNumbers.KeySeparator}{registrationNumbersIndex}.typeDnBCode"] = registrationNumbers.typeDnBCode.PrintIfAvailable();
-            metadata.Properties[$"{StaticDnBVocabulary.RegistrationNumbers.KeyPrefix}{StaticDnBVocabulary.RegistrationNumbers.KeySeparator}{registrationNumbersIndex}.registrationNumberClass.description"] = registrationNumbers.registrationNumberClass?.description;
-            metadata.Properties[$"{StaticDnBVocabulary.RegistrationNumbers.KeyPrefix}{StaticDnBVocabulary.RegistrationNumbers.KeySeparator}{registrationNumbersIndex}.registrationNumberClass.dnbCode"] = registrationNumbers.registrationNumberClass?.dnbCode.PrintIfAvailable();
+            metadata.Properties[$"{StaticDnBVocabulary.RegistrationNumbers.KeyPrefix}{StaticDnBVocabulary.RegistrationNumbers.KeySeparator}{registrationNumbersIndex}.registrationNumber"] = registrationNumber.registrationNumber;
+            metadata.Properties[$"{StaticDnBVocabulary.RegistrationNumbers.KeyPrefix}{StaticDnBVocabulary.RegistrationNumbers.KeySeparator}{registrationNumbersIndex}.typeDescription"] = registrationNumber.typeDescription;
+            metadata.Properties[$"{StaticDnBVocabulary.RegistrationNumbers.KeyPrefix}{StaticDnBVocabulary.RegistrationNumbers.KeySeparator}{registrationNumbersIndex}.typeDnBCode"] = registrationNumber.typeDnBCode.PrintIfAvailable();
+            metadata.Properties[$"{StaticDnBVocabulary.RegistrationNumbers.KeyPrefix}{StaticDnBVocabulary.RegistrationNumbers.KeySeparator}{registrationNumbersIndex}.registrationNumberClass.description"] = registrationNumber.registrationNumberClass?.description;
+            metadata.Properties[$"{StaticDnBVocabulary.RegistrationNumbers.KeyPrefix}{StaticDnBVocabulary.RegistrationNumbers.KeySeparator}{registrationNumbersIndex}.registrationNumberClass.dnbCode"] = registrationNumber.registrationNumberClass?.dnbCode.PrintIfAvailable();
 
             registrationNumbersIndex++;
         }
@@ -500,13 +477,24 @@ public class DnBExternalSearchProvider : ExternalSearchProviderBase, IExtendedEn
         metadata.Properties[StaticDnBVocabulary.BusinessPartner.HierarchyLevel] = resultItem.Data.organization?.corporateLinkage?.hierarchyLevel.PrintIfAvailable();
         metadata.Properties[StaticDnBVocabulary.BusinessPartner.GlobalUltimateFamilyTreeMembersCount] = resultItem.Data.organization?.corporateLinkage?.globalUltimateFamilyTreeMembersCount.PrintIfAvailable();
 
-        //metadata.Properties[StaticDnBVocabulary.BusinessPartner.WebsiteUrl] = resultItem.Data.organization.websiteAddress.First()..PrintIfAvailable();
+        // Number of Employees
+        metadata.Properties[StaticDnBVocabulary.BusinessPartner.NumberOfEmployees] = resultItem.Data.organization?.numberOfEmployees?.FirstOrDefault()?.value.PrintIfAvailable();
+        metadata.Properties[StaticDnBVocabulary.BusinessPartner.GlobalUltimateNumberOfEmployees] = resultItem.Data.organization?.corporateLinkage?.globalUltimate?.numberOfEmployees?.FirstOrDefault()?.value.PrintIfAvailable();
+        metadata.Properties[StaticDnBVocabulary.BusinessPartner.DomesticUltimateNumberOfEmployees] = resultItem.Data.organization?.corporateLinkage?.domesticUltimate?.numberOfEmployees?.FirstOrDefault()?.value.PrintIfAvailable();
+
+        // Yearly Revenue
+        metadata.Properties[StaticDnBVocabulary.BusinessPartner.YearlyRevenue] = $"{resultItem.Data.organization?.financials?.FirstOrDefault()?.yearlyRevenue.FirstOrDefault().value} {resultItem.Data.organization?.financials?.FirstOrDefault()?.yearlyRevenue.FirstOrDefault().currency}";
+        metadata.Properties[StaticDnBVocabulary.BusinessPartner.GlobalUltimateYearlyRevenue] = $"{resultItem.Data.organization?.corporateLinkage?.globalUltimate?.financials?.FirstOrDefault()?.yearlyRevenue?.FirstOrDefault()?.value} {resultItem.Data.organization?.corporateLinkage?.globalUltimate?.financials?.FirstOrDefault()?.yearlyRevenue?.FirstOrDefault()?.currency}";
+        metadata.Properties[StaticDnBVocabulary.BusinessPartner.DomesticUltimateYearlyRevenue] = $"{resultItem.Data.organization?.corporateLinkage?.domesticUltimate?.financials?.FirstOrDefault()?.yearlyRevenue?.FirstOrDefault()?.value} {resultItem.Data.organization?.corporateLinkage?.domesticUltimate?.financials?.FirstOrDefault()?.yearlyRevenue?.FirstOrDefault()?.currency}";
     }
 
-    private static void PopulateIndustryCodes(IEntityMetadata metadata, IExternalSearchQueryResult<DNBResponse> resultItem)
+    private static void PopulateIndustryCodes(IEntityMetadata metadata, IExternalSearchQueryResult<DNBResponse> resultItem, DnBExternalSearchJobData jobData)
     {
+        var selectedTypes = !string.IsNullOrWhiteSpace(jobData.IndustryCodesKey) ? jobData.IndustryCodesKey.Split(",") : [];
+
+        var industryCodes = resultItem.Data.organization?.industryCodes.Where(x => x.typeDnBCode > 0 && selectedTypes.Contains(x.typeDnBCode.ToString()));
         var industryCodesIndex = 0;
-        foreach (var industryCode in resultItem.Data.organization?.industryCodes ?? Enumerable.Empty<IndustryCode>())
+        foreach (var industryCode in industryCodes ?? [])
         {
             metadata.Properties[$"{StaticDnBVocabulary.Industry.KeyPrefix}{StaticDnBVocabulary.Industry.KeySeparator}{industryCodesIndex}.description"] = industryCode.description;
             metadata.Properties[$"{StaticDnBVocabulary.Industry.KeyPrefix}{StaticDnBVocabulary.Industry.KeySeparator}{industryCodesIndex}.typeDescription"] = industryCode.typeDescription;
@@ -537,7 +525,8 @@ public class DnBExternalSearchProvider : ExternalSearchProviderBase, IExtendedEn
     public IEntityMetadata GetPrimaryEntityMetadata(ExecutionContext context, IExternalSearchQueryResult result, IExternalSearchRequest request, IDictionary<string, object> config, IProvider provider)
     {
         var resultItem = result.As<DNBResponse>();
-        return this.CreateMetadata(resultItem, request);
+        var jobData = new DnBExternalSearchJobData(config);
+        return this.CreateMetadata(resultItem, request, jobData);
     }
 
     public IPreviewImage GetPrimaryEntityPreviewImage(ExecutionContext context, IExternalSearchQueryResult result, IExternalSearchRequest request, IDictionary<string, object> config, IProvider provider)

--- a/src/ExternalSearch.Providers.Dnb/DnBExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.Dnb/DnBExternalSearchProvider.cs
@@ -415,14 +415,14 @@ public class DnBExternalSearchProvider : ExternalSearchProviderBase, IExtendedEn
         metadata.Properties[StaticDnBVocabulary.BusinessPartner.BusinessEntityTypeDescription] = resultItem.Data.organization?.businessEntityType?.description;
 
         // Trade Style Names
-        var tradeStyleNames = resultItem.Data.organization?.tradeStyleNames?.Select(t => t.name).Where(n => !string.IsNullOrEmpty(n)) ?? [];
+        var tradeStyleNames = resultItem.Data.organization?.tradeStyleNames?.Select(t => t.name).Where(n => !string.IsNullOrEmpty(n));
         metadata.Properties[StaticDnBVocabulary.BusinessPartner.TradeStyleNames] = string.Join(" | ", tradeStyleNames);
 
         // WebsiteAddress
         var website = resultItem.Data.organization?.websiteAddress?.FirstOrDefault();
         if (website != null)
         {
-            metadata.Properties[StaticDnBVocabulary.BusinessPartner.WebsiteUrl] = website?.url;
+            metadata.Properties[StaticDnBVocabulary.BusinessPartner.WebsiteUrl] = website.url;
         }
 
         // Telephone
@@ -436,7 +436,7 @@ public class DnBExternalSearchProvider : ExternalSearchProviderBase, IExtendedEn
         var fax = resultItem.Data.organization?.fax?.FirstOrDefault();
         if (fax != null)
         {
-            metadata.Properties[StaticDnBVocabulary.BusinessPartner.Fax] = $"+{fax?.isdCode} {fax?.faxNumber}";
+            metadata.Properties[StaticDnBVocabulary.BusinessPartner.Fax] = $"+{fax.isdCode} {fax.faxNumber}";
         }
 
         // Stock Exchanges
@@ -449,18 +449,22 @@ public class DnBExternalSearchProvider : ExternalSearchProviderBase, IExtendedEn
         }
 
         // Registration Numbers
-        var selectedRegistrationNumberTypes = !string.IsNullOrWhiteSpace(jobData.RegistrationNumbersKey) ? jobData.RegistrationNumbersKey.Split(",") : [];
-        var registrationNumbers = resultItem.Data.organization?.registrationNumbers.Where(x => x.typeDnBCode > 0 && selectedRegistrationNumberTypes.Contains(x.typeDnBCode.ToString()));
-        var registrationNumbersIndex = 0;
-        foreach (var registrationNumber in registrationNumbers ?? [])
-        {
-            metadata.Properties[$"{StaticDnBVocabulary.RegistrationNumbers.KeyPrefix}{StaticDnBVocabulary.RegistrationNumbers.KeySeparator}{registrationNumbersIndex}.registrationNumber"] = registrationNumber.registrationNumber;
-            metadata.Properties[$"{StaticDnBVocabulary.RegistrationNumbers.KeyPrefix}{StaticDnBVocabulary.RegistrationNumbers.KeySeparator}{registrationNumbersIndex}.typeDescription"] = registrationNumber.typeDescription;
-            metadata.Properties[$"{StaticDnBVocabulary.RegistrationNumbers.KeyPrefix}{StaticDnBVocabulary.RegistrationNumbers.KeySeparator}{registrationNumbersIndex}.typeDnBCode"] = registrationNumber.typeDnBCode.PrintIfAvailable();
-            metadata.Properties[$"{StaticDnBVocabulary.RegistrationNumbers.KeyPrefix}{StaticDnBVocabulary.RegistrationNumbers.KeySeparator}{registrationNumbersIndex}.registrationNumberClass.description"] = registrationNumber.registrationNumberClass?.description;
-            metadata.Properties[$"{StaticDnBVocabulary.RegistrationNumbers.KeyPrefix}{StaticDnBVocabulary.RegistrationNumbers.KeySeparator}{registrationNumbersIndex}.registrationNumberClass.dnbCode"] = registrationNumber.registrationNumberClass?.dnbCode.PrintIfAvailable();
+        var selectedRegistrationNumberTypes = !string.IsNullOrWhiteSpace(jobData.RegistrationNumbersKey) ? jobData.RegistrationNumbersKey.Split(",") : Array.Empty<string>();
 
-            registrationNumbersIndex++;
+        if (selectedRegistrationNumberTypes.Any())
+        {
+            var registrationNumbers = resultItem.Data.organization?.registrationNumbers?.Where(x => x.typeDnBCode > 0 && selectedRegistrationNumberTypes.Contains(x.typeDnBCode.ToString()));
+            var registrationNumbersIndex = 0;
+            foreach (var registrationNumber in registrationNumbers ?? Enumerable.Empty<RegistrationNumber>())
+            {
+                metadata.Properties[$"{StaticDnBVocabulary.RegistrationNumbers.KeyPrefix}{StaticDnBVocabulary.RegistrationNumbers.KeySeparator}{registrationNumbersIndex}.registrationNumber"] = registrationNumber.registrationNumber;
+                metadata.Properties[$"{StaticDnBVocabulary.RegistrationNumbers.KeyPrefix}{StaticDnBVocabulary.RegistrationNumbers.KeySeparator}{registrationNumbersIndex}.typeDescription"] = registrationNumber.typeDescription;
+                metadata.Properties[$"{StaticDnBVocabulary.RegistrationNumbers.KeyPrefix}{StaticDnBVocabulary.RegistrationNumbers.KeySeparator}{registrationNumbersIndex}.typeDnBCode"] = registrationNumber.typeDnBCode.PrintIfAvailable();
+                metadata.Properties[$"{StaticDnBVocabulary.RegistrationNumbers.KeyPrefix}{StaticDnBVocabulary.RegistrationNumbers.KeySeparator}{registrationNumbersIndex}.registrationNumberClass.description"] = registrationNumber.registrationNumberClass?.description;
+                metadata.Properties[$"{StaticDnBVocabulary.RegistrationNumbers.KeyPrefix}{StaticDnBVocabulary.RegistrationNumbers.KeySeparator}{registrationNumbersIndex}.registrationNumberClass.dnbCode"] = registrationNumber.registrationNumberClass?.dnbCode.PrintIfAvailable();
+
+                registrationNumbersIndex++;
+            }
         }
 
         // Corporate Linkage
@@ -483,18 +487,24 @@ public class DnBExternalSearchProvider : ExternalSearchProviderBase, IExtendedEn
         metadata.Properties[StaticDnBVocabulary.BusinessPartner.DomesticUltimateNumberOfEmployees] = resultItem.Data.organization?.corporateLinkage?.domesticUltimate?.numberOfEmployees?.FirstOrDefault()?.value.PrintIfAvailable();
 
         // Yearly Revenue
-        metadata.Properties[StaticDnBVocabulary.BusinessPartner.YearlyRevenue] = $"{resultItem.Data.organization?.financials?.FirstOrDefault()?.yearlyRevenue.FirstOrDefault().value} {resultItem.Data.organization?.financials?.FirstOrDefault()?.yearlyRevenue.FirstOrDefault().currency}";
+        metadata.Properties[StaticDnBVocabulary.BusinessPartner.YearlyRevenue] = $"{resultItem.Data.organization?.financials?.FirstOrDefault()?.yearlyRevenue?.FirstOrDefault()?.value} {resultItem.Data.organization?.financials?.FirstOrDefault()?.yearlyRevenue?.FirstOrDefault()?.currency}";
         metadata.Properties[StaticDnBVocabulary.BusinessPartner.GlobalUltimateYearlyRevenue] = $"{resultItem.Data.organization?.corporateLinkage?.globalUltimate?.financials?.FirstOrDefault()?.yearlyRevenue?.FirstOrDefault()?.value} {resultItem.Data.organization?.corporateLinkage?.globalUltimate?.financials?.FirstOrDefault()?.yearlyRevenue?.FirstOrDefault()?.currency}";
         metadata.Properties[StaticDnBVocabulary.BusinessPartner.DomesticUltimateYearlyRevenue] = $"{resultItem.Data.organization?.corporateLinkage?.domesticUltimate?.financials?.FirstOrDefault()?.yearlyRevenue?.FirstOrDefault()?.value} {resultItem.Data.organization?.corporateLinkage?.domesticUltimate?.financials?.FirstOrDefault()?.yearlyRevenue?.FirstOrDefault()?.currency}";
     }
 
     private static void PopulateIndustryCodes(IEntityMetadata metadata, IExternalSearchQueryResult<DNBResponse> resultItem, DnBExternalSearchJobData jobData)
     {
-        var selectedTypes = !string.IsNullOrWhiteSpace(jobData.IndustryCodesKey) ? jobData.IndustryCodesKey.Split(",") : [];
+        var selectedTypes = !string.IsNullOrWhiteSpace(jobData.IndustryCodesKey) ? jobData.IndustryCodesKey.Split(",") : Array.Empty<string>();
 
-        var industryCodes = resultItem.Data.organization?.industryCodes.Where(x => x.typeDnBCode > 0 && selectedTypes.Contains(x.typeDnBCode.ToString()));
+        if (!selectedTypes.Any()) return;
+
+        var industryCodeValues = resultItem.Data.organization?.industryCodes?.Where(x => x.typeDnBCode > 0 && selectedTypes.Contains(x.typeDnBCode.ToString()));
+
+        var industryCodeList = industryCodeValues?.ToList();
+        if (industryCodeValues == null || !industryCodeList.Any()) return;
+
         var industryCodesIndex = 0;
-        foreach (var industryCode in industryCodes ?? [])
+        foreach (var industryCode in industryCodeList)
         {
             metadata.Properties[$"{StaticDnBVocabulary.Industry.KeyPrefix}{StaticDnBVocabulary.Industry.KeySeparator}{industryCodesIndex}.description"] = industryCode.description;
             metadata.Properties[$"{StaticDnBVocabulary.Industry.KeyPrefix}{StaticDnBVocabulary.Industry.KeySeparator}{industryCodesIndex}.typeDescription"] = industryCode.typeDescription;

--- a/src/ExternalSearch.Providers.Dnb/Model/DnBResponse/DnBResponse.cs
+++ b/src/ExternalSearch.Providers.Dnb/Model/DnBResponse/DnBResponse.cs
@@ -235,6 +235,8 @@ public class Organization
     public SocioEconomicInformation socioEconomicInformation { get; set; }
     public bool isStandalone { get; set; }
     public CorporateLinkage corporateLinkage { get; set; }
+    public GlobalUltimate globalUltimate { get; set; }
+    public DomesticUltimate domesticUltimate { get; set; }
 }
 
 public class Parent

--- a/src/ExternalSearch.Providers.Dnb/Model/DnBResponse/DnBResponse.cs
+++ b/src/ExternalSearch.Providers.Dnb/Model/DnBResponse/DnBResponse.cs
@@ -71,6 +71,8 @@ public class DomesticUltimate
     public string duns { get; set; }
     public string primaryName { get; set; }
     public PrimaryAddress primaryAddress { get; set; }
+    public List<NumberOfEmployee> numberOfEmployees { get; set; }
+    public List<Financial> financials { get; set; }
 }
 
 public class DunsControlStatus
@@ -121,6 +123,8 @@ public class GlobalUltimate
     public string duns { get; set; }
     public string primaryName { get; set; }
     public PrimaryAddress primaryAddress { get; set; }
+    public List<NumberOfEmployee> numberOfEmployees { get; set; }
+    public List<Financial> financials { get; set; }
 }
 
 public class HeadQuarter
@@ -186,6 +190,8 @@ public class MostSeniorPrincipal
 public class NumberOfEmployee
 {
     public int value { get; set; }
+    public int minimumValue { get; set; }
+    public int maximumValue { get; set; }
     public string informationScopeDescription { get; set; }
     public int informationScopeDnBCode { get; set; }
     public string reliabilityDescription { get; set; }
@@ -434,6 +440,7 @@ public class StockExchange
     public string tickerName { get; set; }
     public ExchangeName exchangeName { get; set; }
     public ExchangeCountry exchangeCountry { get; set; }
+    public bool? isPrimary { get; set; }
 }
 
 public class ExchangeName

--- a/src/ExternalSearch.Providers.Dnb/Vocabularies/DnBVocabulary.cs
+++ b/src/ExternalSearch.Providers.Dnb/Vocabularies/DnBVocabulary.cs
@@ -1,4 +1,5 @@
 ﻿using CluedIn.Core.Data.Vocabularies;
+using CluedIn.ExternalSearch.Providers.DnB.Model.DnBResponse;
 
 namespace CluedIn.ExternalSearch.Providers.DnB.Vocabularies;
 
@@ -68,6 +69,8 @@ public class DnBVocabulary : SimpleVocabulary
             HeadQuarterPrimaryAddressStreetLine1 = group.Add(new VocabularyKey(nameof(HeadQuarterPrimaryAddressStreetLine1), VocabularyKeyDataType.Text, VocabularyKeyVisibility.Visible));
             HeadQuarterPrimaryAddressStreetLine2 = group.Add(new VocabularyKey(nameof(HeadQuarterPrimaryAddressStreetLine2), VocabularyKeyDataType.Text, VocabularyKeyVisibility.Visible));
             WebsiteUrl = group.Add(new VocabularyKey(nameof(WebsiteUrl), VocabularyKeyDataType.Text, VocabularyKeyVisibility.Visible));
+            Telephone = group.Add(new VocabularyKey(nameof(Telephone), VocabularyKeyDataType.Text, VocabularyKeyVisibility.Visible));
+            Fax = group.Add(new VocabularyKey(nameof(Fax), VocabularyKeyDataType.Text, VocabularyKeyVisibility.Visible));
             RegistrationNumber2 = group.Add(new VocabularyKey(nameof(RegistrationNumber2), VocabularyKeyDataType.Text, VocabularyKeyVisibility.Visible));
             DunsControlStatusFullReportDate = group.Add(new VocabularyKey(nameof(DunsControlStatusFullReportDate), VocabularyKeyDataType.Text, VocabularyKeyVisibility.Visible));
             DunsControlStatusLastUpdateDate = group.Add(new VocabularyKey(nameof(DunsControlStatusLastUpdateDate), VocabularyKeyDataType.Text, VocabularyKeyVisibility.Visible));
@@ -84,6 +87,16 @@ public class DnBVocabulary : SimpleVocabulary
             ConfidenceScore = group.Add(new VocabularyKey("_cluedin_confidenceScore"));
             HierarchyLevel = group.Add(new VocabularyKey(nameof(HierarchyLevel), VocabularyKeyDataType.Text, VocabularyKeyVisibility.Visible));
             GlobalUltimateFamilyTreeMembersCount = group.Add(new VocabularyKey(nameof(GlobalUltimateFamilyTreeMembersCount), VocabularyKeyDataType.Text, VocabularyKeyVisibility.Visible));
+            TradeStyleNames = group.Add(new VocabularyKey(nameof(TradeStyleNames), VocabularyKeyDataType.Text, VocabularyKeyVisibility.Visible));
+            StockExchangeTickerName = group.Add(new VocabularyKey(nameof(StockExchangeTickerName), VocabularyKeyDataType.Text, VocabularyKeyVisibility.Visible));
+            StockExchangeName = group.Add(new VocabularyKey(nameof(StockExchangeName), VocabularyKeyDataType.Text, VocabularyKeyVisibility.Visible));
+            StockExchangeCountryCode = group.Add(new VocabularyKey(nameof(StockExchangeCountryCode), VocabularyKeyDataType.Text, VocabularyKeyVisibility.Visible));
+            NumberOfEmployees = group.Add(new VocabularyKey(nameof(NumberOfEmployees), VocabularyKeyDataType.Text, VocabularyKeyVisibility.Visible));
+            GlobalUltimateNumberOfEmployees = group.Add(new VocabularyKey(nameof(GlobalUltimateNumberOfEmployees), VocabularyKeyDataType.Text, VocabularyKeyVisibility.Visible));
+            DomesticUltimateNumberOfEmployees = group.Add(new VocabularyKey(nameof(DomesticUltimateNumberOfEmployees), VocabularyKeyDataType.Text, VocabularyKeyVisibility.Visible));
+            YearlyRevenue = group.Add(new VocabularyKey(nameof(YearlyRevenue), VocabularyKeyDataType.Text, VocabularyKeyVisibility.Visible));
+            GlobalUltimateYearlyRevenue = group.Add(new VocabularyKey(nameof(GlobalUltimateYearlyRevenue), VocabularyKeyDataType.Text, VocabularyKeyVisibility.Visible));
+            DomesticUltimateYearlyRevenue = group.Add(new VocabularyKey(nameof(DomesticUltimateYearlyRevenue), VocabularyKeyDataType.Text, VocabularyKeyVisibility.Visible));
         });
     }
 
@@ -143,6 +156,8 @@ public class DnBVocabulary : SimpleVocabulary
     public VocabularyKey HeadQuarterPrimaryAddressStreetLine1 { get; protected set; }
     public VocabularyKey HeadQuarterPrimaryAddressStreetLine2 { get; protected set; }
     public VocabularyKey WebsiteUrl { get; protected set; }
+    public VocabularyKey Telephone { get; protected set; }
+    public VocabularyKey Fax { get; protected set; }
     public VocabularyKey RegistrationNumber2 { get; protected set; }
     public VocabularyKey DunsControlStatusFullReportDate { get; protected set; }
     public VocabularyKey DunsControlStatusLastUpdateDate { get; protected set; }
@@ -158,4 +173,14 @@ public class DnBVocabulary : SimpleVocabulary
     public VocabularyKey ConfidenceScore { get; protected set; }
     public VocabularyKey HierarchyLevel { get; protected set; }
     public VocabularyKey GlobalUltimateFamilyTreeMembersCount { get; protected set; }
+    public VocabularyKey TradeStyleNames { get; protected set; }
+    public VocabularyKey StockExchangeTickerName { get; protected set; }
+    public VocabularyKey StockExchangeName { get; protected set; }
+    public VocabularyKey StockExchangeCountryCode { get; protected set; }
+    public VocabularyKey NumberOfEmployees { get; protected set; }
+    public VocabularyKey GlobalUltimateNumberOfEmployees { get; protected set; }
+    public VocabularyKey DomesticUltimateNumberOfEmployees { get; protected set; }
+    public VocabularyKey YearlyRevenue { get; protected set; }
+    public VocabularyKey GlobalUltimateYearlyRevenue { get; protected set; }
+    public VocabularyKey DomesticUltimateYearlyRevenue { get; protected set; }
 }

--- a/src/ExternalSearch.Providers.Dnb/Vocabularies/DnBVocabulary.cs
+++ b/src/ExternalSearch.Providers.Dnb/Vocabularies/DnBVocabulary.cs
@@ -1,5 +1,4 @@
 ﻿using CluedIn.Core.Data.Vocabularies;
-using CluedIn.ExternalSearch.Providers.DnB.Model.DnBResponse;
 
 namespace CluedIn.ExternalSearch.Providers.DnB.Vocabularies;
 


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

Included YearlyRevenue and NumberOfEmployees from new data block
Added 2 new controls that allow user to decide which industryCodes and RegistrationNumbers will be returned
<img width="1913" height="942" alt="image" src="https://github.com/user-attachments/assets/02d3290f-504b-4969-94d1-c2cf02818cd9" />


## How has it been tested? <!-- Remove if not needed -->
Manually in local

