### PR TITLE
fix: Add Provider Definition Id to OriginEntityCode to allow two or more enrichers enrich simultaneously

### DIFF
--- a/docs/4.6.1-release-notes.md
+++ b/docs/4.6.1-release-notes.md
@@ -9,6 +9,7 @@
 - Convert globalUltimate, domesticUltimate and industryCodes clues into properties to solve merging issues due to many identical clues
 - Resolve null exception issues
 - Standardize vocabulary key names
+- Allow two or more active enrichers to enrich simultaneously
 
 ### Chore
 - Code clean up

--- a/src/ExternalSearch.Providers.Dnb/DnBExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.Dnb/DnBExternalSearchProvider.cs
@@ -12,7 +12,6 @@ using CluedIn.ExternalSearch.Providers.DnB.Model.AuthResponse;
 using CluedIn.ExternalSearch.Providers.DnB.Model.DnBResponse;
 using CluedIn.ExternalSearch.Providers.DnB.Vocabularies;
 using Microsoft.Extensions.Caching.Memory;
-using Nest;
 using Newtonsoft.Json;
 using RestSharp;
 using System;
@@ -271,14 +270,14 @@ public class DnBExternalSearchProvider : ExternalSearchProviderBase, IExtendedEn
 
     private EntityCode GetOriginEntityCode(IExternalSearchQueryResult<DNBResponse> resultItem, IExternalSearchRequest request, IExternalSearchQuery query)
     {
-        return new EntityCode(request.EntityMetaData.EntityType, this.GetCodeOrigin(), resultItem.Data.organization?.duns ?? $"{query.QueryKey}{request.EntityMetaData.OriginEntityCode}".ToDeterministicGuid().ToString());
+        return new EntityCode(request.EntityMetaData.EntityType, this.GetCodeOrigin(query), resultItem.Data.organization?.duns ?? $"{query.QueryKey}{request.EntityMetaData.OriginEntityCode}".ToDeterministicGuid().ToString());
     }
 
     /// <summary>Gets the code origin.</summary>
     /// <returns>The code origin</returns>
-    private CodeOrigin GetCodeOrigin()
+    private CodeOrigin GetCodeOrigin(IExternalSearchQuery query)
     {
-        return CodeOrigin.CluedIn.CreateSpecific("DnB");
+        return CodeOrigin.CluedIn.CreateSpecific($"DnB_{query.ProviderDefinitionId}");
     }
 
     private void PopulateMetadata(IEntityMetadata metadata, IExternalSearchQueryResult<DNBResponse> resultItem, IExternalSearchRequest request, DnBExternalSearchJobData jobData)


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#55099](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/55099)

Add Provider Definition Id to `OriginEntityCode` so that the clues are not deduplicated in method `DeduplicateClues(IEnumerable<Clue> clues)`

Both enrichers are now having results in Preview tab after triggering enrichment.


## How has it been tested? <!-- Remove if not needed -->
Manually in local

