### PR TITLE
fix: Throw error when failed to get access token

### DIFF
--- a/docs/4.6.1-release-notes.md
+++ b/docs/4.6.1-release-notes.md
@@ -9,6 +9,7 @@
 - Convert globalUltimate, domesticUltimate and industryCodes clues into properties to solve merging issues due to many identical clues
 - Resolve null exception issues
 - Standardize vocabulary key names
+- Throw error when failed to get auth token
 
 ### Chore
 - Code clean up

--- a/docs/4.6.1-release-notes.md
+++ b/docs/4.6.1-release-notes.md
@@ -9,7 +9,7 @@
 - Convert globalUltimate, domesticUltimate and industryCodes clues into properties to solve merging issues due to many identical clues
 - Resolve null exception issues
 - Standardize vocabulary key names
-- Throw error when failed to get auth token
+- Throw error when failed to get access token
 
 ### Chore
 - Code clean up

--- a/src/ExternalSearch.Providers.Dnb/DnBExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.Dnb/DnBExternalSearchProvider.cs
@@ -12,7 +12,6 @@ using CluedIn.ExternalSearch.Providers.DnB.Model.AuthResponse;
 using CluedIn.ExternalSearch.Providers.DnB.Model.DnBResponse;
 using CluedIn.ExternalSearch.Providers.DnB.Vocabularies;
 using Microsoft.Extensions.Caching.Memory;
-using Nest;
 using Newtonsoft.Json;
 using RestSharp;
 using System;
@@ -245,6 +244,16 @@ public class DnBExternalSearchProvider : ExternalSearchProviderBase, IExtendedEn
             request.AddParameter("application/json", body, ParameterType.RequestBody);
             var response = await restClient.ExecuteAsync(request);
             var responseContent = JsonUtility.Deserialize<AuthResponse>(response.Content);
+
+            if (!response.IsSuccessful)
+            {
+                throw new Exception($"Could not get access token. StatusCode: {response.StatusCode}, Status Description: {response.StatusDescription}, Error Message:{response.ErrorMessage}", response.ErrorException);
+            }
+
+            if (string.IsNullOrEmpty(responseContent?.AccessToken))
+            {
+                throw new Exception($"Access token returned is empty. StatusCode: {response.StatusCode}, Status Description: {response.StatusDescription}, Error Message:{response.ErrorMessage}");
+            }
 
             using (var entry = memoryCache.CreateEntry(cacheKey))
             {


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#55518](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/55518)

Properly handle empty access token by throwing better error message 

## How has it been tested? <!-- Remove if not needed -->
Manually in local
