### PR TITLE
fix: Reference IMemoryCache from core instead of Microsoft package

### DIFF
--- a/docs/4.6.1-release-notes.md
+++ b/docs/4.6.1-release-notes.md
@@ -10,6 +10,7 @@
 - Resolve null exception issues
 - Standardize vocabulary key names
 - Throw error when failed to get access token
+- Resolve IMemoryCache from the core project instead of directly from the Microsoft package
 
 ### Chore
 - Code clean up

--- a/src/ExternalSearch.Providers.Dnb/DnBExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.Dnb/DnBExternalSearchProvider.cs
@@ -11,7 +11,6 @@ using CluedIn.ExternalSearch.Providers.DnB.Custom;
 using CluedIn.ExternalSearch.Providers.DnB.Model.AuthResponse;
 using CluedIn.ExternalSearch.Providers.DnB.Model.DnBResponse;
 using CluedIn.ExternalSearch.Providers.DnB.Vocabularies;
-using Microsoft.Extensions.Caching.Memory;
 using Newtonsoft.Json;
 using RestSharp;
 using System;
@@ -21,6 +20,7 @@ using System.Net;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using CluedIn.Core.Caching.MicrosoftExtensions;
 using EntityType = CluedIn.Core.Data.EntityType;
 using ExecutionContext = CluedIn.Core.ExecutionContext;
 


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#55594](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/55594)

Getting the error shown in the screenshot when trying to enrich in the MT SaaS platform. Trying to change the reference to use IMemoryCache from core instead of the one provided by Microsoft. IMemoryCache was registered by CopilotInstaller in core.

<img width="1912" height="638" alt="image" src="https://github.com/user-attachments/assets/a59512bb-527e-4879-a91c-6a70865437aa" />

## How has it been tested? <!-- Remove if not needed -->
Manually in local
