### PR TITLE
feat: Set default values for Candidate Maximum Quantity and Confidence Lower Level Threshold

### DIFF
--- a/docs/4.6.2-release-notes.md
+++ b/docs/4.6.2-release-notes.md
@@ -1,0 +1,2 @@
+### Features
+- Set default values for the Candidate Maximum Quantity and Confidence Lower Level Threshold controls

--- a/src/ExternalSearch.Providers.Dnb/DnBConstants.cs
+++ b/src/ExternalSearch.Providers.Dnb/DnBConstants.cs
@@ -204,6 +204,10 @@ public static class DnBConstants
             {
                 new() { { "regex", "[^0-9]" }, { "message", "Non-numeric values are not allowed." } },
                 new() { { "regex", "^(?:0|10[1-9]|1[1-9]\\d|[2-9]\\d{2,})$" }, { "message", "Valid values: 1 to 100" } }
+            },
+            Options = new Dictionary<string, object>
+            {
+                { "defaultValue", 10 }
             }
         },
         new()
@@ -217,6 +221,10 @@ public static class DnBConstants
             {
                 new() { { "regex", "[^0-9]" }, { "message", "Non-numeric values are not allowed." } },
                 new() { { "regex", "^(?:0|1[1-9]|[2-9]\\d|\\d{3,})$" }, { "message", "Valid values: 1 to 10" } }
+            },
+            Options = new Dictionary<string, object>
+            {
+                { "defaultValue", 4 }
             }
         },
         new()
@@ -301,6 +309,10 @@ public static class DnBConstants
             ValidationRules = new List<Dictionary<string, string>>
             {
                 new() { { "regex", "[^0-9,]" }, { "message", "Non-numeric values are not allowed." } }
+            },
+            Options = new Dictionary<string, object>
+            {
+                { "defaultValue", string.Empty }
             }
         },
         new()
@@ -313,6 +325,10 @@ public static class DnBConstants
             ValidationRules = new List<Dictionary<string, string>>
             {
                 new() { { "regex", "[^0-9,]" }, { "message", "Non-numeric values are not allowed." } }
+            },
+            Options = new Dictionary<string, object>
+            {
+                { "defaultValue", string.Empty }
             }
         },
         // Match and Append 
@@ -407,6 +423,10 @@ public static class DnBConstants
                 ValidationRules = new List<Dictionary<string, string>>
                 {
                     new() { { "regex", @"(^|[\r\n])(=|[^=\r\n]+$|[^=\r\n]+=\r?$)" }, { "message", "Invalid format. Each line must be in Property=JSONPath format." } }
+                },
+                Options = new Dictionary<string, object>
+                {
+                    { "defaultValue", string.Empty }
                 }
             }
         }.Concat(Properties)


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#56626](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/56626)

Candidate Maximum Quantity and Confidence Lower Level Threshold Value control will have default value when creating enricher
<img width="1691" height="936" alt="image" src="https://github.com/user-attachments/assets/611efe0a-68bb-4dbb-a24c-765bcdf10afc" />

## How has it been tested? <!-- Remove if not needed -->
Manually in local
