### PR TITLE
feat: Update enricher version to expire cached results

### DIFF
--- a/docs/4.6.2-release-notes.md
+++ b/docs/4.6.2-release-notes.md
@@ -1,0 +1,2 @@
+### Features
+- Update enricher version to expire cached result

--- a/src/ExternalSearch.Providers.Dnb/DnBExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.Dnb/DnBExternalSearchProvider.cs
@@ -44,6 +44,7 @@ public class DnBExternalSearchProvider : ExternalSearchProviderBase, IExtendedEn
     public IEnumerable<Control> Properties { get; } = new List<Control>();
     public Guide Guide => null;
     public IntegrationType Type => IntegrationType.Enrichment;
+    public override Version Version => new Version("4.6.2.0"); // Update version to expire cached results when we make changes like changing the result type
 
     private static readonly EntityType[] DefaultAcceptedEntityTypes = { EntityType.Organization };
     private static readonly SemaphoreSlim semaphore = new(1, 1);


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#56568](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/56568)

Update enricher version from default `1.0.0.0` to `4.6.2.0` to expire the cached  results as there is changes to the result type. In my opinion, the version should only be updated when the cache results need to be expired. 

## How has it been tested? <!-- Remove if not needed -->
Manually in local
